### PR TITLE
Enable SSL for provided api data

### DIFF
--- a/src/Sseffa/VideoApi/Services/ServiceTrait.php
+++ b/src/Sseffa/VideoApi/Services/ServiceTrait.php
@@ -50,6 +50,7 @@ trait ServiceTrait {
         if (extension_loaded('curl')) {
             $ch = curl_init(str_replace('{id}', $this->id, $url));
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
             $json = curl_exec($ch);
         } else {
             $json = @file_get_contents(str_replace('{id}', $this->id, $url));

--- a/src/Sseffa/VideoApi/Services/Vimeo.php
+++ b/src/Sseffa/VideoApi/Services/Vimeo.php
@@ -15,14 +15,14 @@ class Vimeo implements ServicesInterface {
      *
      * @var String
      */
-    private $baseChannelUrl = 'http://vimeo.com/api/v2/{id}/videos.json';
+    private $baseChannelUrl = 'https://vimeo.com/api/v2/{id}/videos.json';
 
     /**
      * Base Video Url
      *
      * @var String
      */
-    private $baseVideoUrl = 'http://vimeo.com/api/v2/video/{id}.json';
+    private $baseVideoUrl = 'https://vimeo.com/api/v2/video/{id}.json';
 
     /**
      * Id

--- a/src/Sseffa/VideoApi/Services/Youtube.php
+++ b/src/Sseffa/VideoApi/Services/Youtube.php
@@ -15,14 +15,14 @@ class Youtube implements ServicesInterface {
      *
      * @var String
      */
-    private $baseChannelUrl = 'http://gdata.youtube.com/feeds/api/videos?q={id}&v=2&alt=jsonc';
+    private $baseChannelUrl = 'https://gdata.youtube.com/feeds/api/videos?q={id}&v=2&alt=jsonc';
 
     /**
      * Base Video Url
      *
      * @var String
      */
-    private $baseVideoUrl = 'http://gdata.youtube.com/feeds/api/videos/{id}?v=2&alt=jsonc';
+    private $baseVideoUrl = 'https://gdata.youtube.com/feeds/api/videos/{id}?v=2&alt=jsonc';
 
     /**
      * Id


### PR DESCRIPTION
Just to make sure that the served data will be containing links beginning with ‘https’. Api data should by default be served via HTTPS.