### PR TITLE
Update Service Provider for L5.4

### DIFF
--- a/src/Sseffa/VideoApi/VideoApiServiceProvider.php
+++ b/src/Sseffa/VideoApi/VideoApiServiceProvider.php
@@ -33,7 +33,7 @@ class VideoApiServiceProvider extends ServiceProvider
     public function register()
     {
 
-        $this->app['video-api'] = $this->app->share(function ()
+        $this->app->singleton('video-api', function ()
         {
 
             return new VideoApi();


### PR DESCRIPTION
The Service Provider format is no longer available in L5.4

This rewrites it so this package keeps working in L5.4